### PR TITLE
Workout preview and homescreen refinement

### DIFF
--- a/src/components/NextExercisePreview.tsx
+++ b/src/components/NextExercisePreview.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import { Target, TrendingUp, Clock, Dumbbell, Repeat } from 'lucide-react';
+import { Card } from './ui/Card';
+import type { EnhancedExercise } from '../data/workoutData';
+import type { ExerciseHistoryEntry } from '../hooks/useExerciseHistory';
+
+interface NextExercisePreviewProps {
+  exercise: EnhancedExercise;
+  history: ExerciseHistoryEntry[];
+  loading?: boolean;
+}
+
+interface PerformanceData {
+  lastPerformance: ExerciseHistoryEntry | null;
+  personalBest: ExerciseHistoryEntry | null;
+}
+
+function calculatePersonalBest(history: ExerciseHistoryEntry[], exerciseType: string): ExerciseHistoryEntry | null {
+  if (history.length === 0) return null;
+
+  let best = history[0];
+
+  for (const entry of history) {
+    switch (exerciseType) {
+      case 'weight_reps':
+        // For weight exercises, prioritize weight, then reps
+        if (entry.weight && best.weight) {
+          if (entry.weight > best.weight || 
+              (entry.weight === best.weight && entry.reps && best.reps && entry.reps > best.reps)) {
+            best = entry;
+          }
+        } else if (entry.weight && !best.weight) {
+          best = entry;
+        }
+        break;
+      
+      case 'reps_only':
+      case 'reps_only_with_optional_weight':
+        // For rep-only exercises, prioritize reps, then weight if available
+        if (entry.reps && best.reps) {
+          if (entry.reps > best.reps || 
+              (entry.reps === best.reps && entry.weight && best.weight && entry.weight > best.weight)) {
+            best = entry;
+          }
+        } else if (entry.reps && !best.reps) {
+          best = entry;
+        }
+        break;
+      
+      case 'timed':
+        // For timed exercises, prioritize duration
+        if (entry.duration_seconds && best.duration_seconds) {
+          if (entry.duration_seconds > best.duration_seconds) {
+            best = entry;
+          }
+        } else if (entry.duration_seconds && !best.duration_seconds) {
+          best = entry;
+        }
+        break;
+    }
+  }
+
+  return best;
+}
+
+function getPerformanceData(history: ExerciseHistoryEntry[], exerciseType: string): PerformanceData {
+  const lastPerformance = history.length > 0 ? history[0] : null; // History is sorted by date desc
+  const personalBest = calculatePersonalBest(history, exerciseType);
+
+  return { lastPerformance, personalBest };
+}
+
+function formatPerformance(entry: ExerciseHistoryEntry | null, exerciseType: string): string {
+  if (!entry) return 'No previous data';
+
+  const parts: string[] = [];
+
+  if (entry.weight) {
+    parts.push(`${entry.weight} lbs`);
+  }
+
+  if (entry.reps) {
+    parts.push(`${entry.reps} reps`);
+  }
+
+  if (entry.duration_seconds) {
+    const minutes = Math.floor(entry.duration_seconds / 60);
+    const seconds = entry.duration_seconds % 60;
+    if (minutes > 0) {
+      parts.push(`${minutes}:${seconds.toString().padStart(2, '0')}`);
+    } else {
+      parts.push(`${entry.duration_seconds}s`);
+    }
+  }
+
+  return parts.length > 0 ? parts.join(', ') : 'No data';
+}
+
+export function NextExercisePreview({ exercise, history, loading = false }: NextExercisePreviewProps) {
+  const { lastPerformance, personalBest } = getPerformanceData(history, exercise.type);
+
+  if (loading) {
+    return (
+      <Card className="bg-theme-black-lighter border-theme-gold/20">
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <Target className="w-5 h-5 text-theme-gold" />
+            <span className="text-theme-gold font-semibold">Next Exercise</span>
+          </div>
+          <div className="animate-pulse">
+            <div className="h-4 bg-theme-gold/20 rounded w-3/4 mb-2"></div>
+            <div className="h-3 bg-theme-gold/20 rounded w-1/2"></div>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-theme-black-lighter border-theme-gold/30">
+      <div className="space-y-4">
+        {/* Header */}
+        <div className="flex items-center gap-2 pb-2 border-b border-theme-gold/20">
+          <Target className="w-5 h-5 text-theme-gold" />
+          <span className="text-theme-gold font-semibold">Next Exercise</span>
+        </div>
+
+        {/* Exercise Details */}
+        <div className="space-y-2">
+          <h4 className="text-lg font-semibold text-theme-gold">{exercise.name}</h4>
+          <div className="flex items-center gap-4 text-sm text-theme-gold-light">
+            <span className="flex items-center gap-1">
+              <Repeat size={14} />
+              {exercise.sets} sets
+            </span>
+            <span>Target: {exercise.reps}</span>
+          </div>
+        </div>
+
+        {/* Performance History */}
+        <div className="grid grid-cols-1 gap-3">
+          {/* Last Performance */}
+          <div className="bg-theme-black rounded-2x-nested-container p-3">
+            <div className="flex items-center gap-2 mb-2">
+              <Clock className="w-4 h-4 text-theme-gold-dark" />
+              <span className="text-xs font-medium text-theme-gold-dark uppercase tracking-wide">
+                Last Performance
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              {exercise.type.includes('weight') && (
+                <Dumbbell className="w-4 h-4 text-theme-gold-light" />
+              )}
+              {(exercise.type.includes('reps') || exercise.type === 'reps_only') && (
+                <Repeat className="w-4 h-4 text-theme-gold-light" />
+              )}
+              {exercise.type === 'timed' && (
+                <Clock className="w-4 h-4 text-theme-gold-light" />
+              )}
+              <span className="text-theme-gold-light text-sm">
+                {formatPerformance(lastPerformance, exercise.type)}
+              </span>
+            </div>
+            {lastPerformance && (
+              <div className="text-xs text-theme-gold-dark mt-1">
+                {lastPerformance.date}
+              </div>
+            )}
+          </div>
+
+          {/* Personal Best */}
+          <div className="bg-theme-black rounded-2x-nested-container p-3">
+            <div className="flex items-center gap-2 mb-2">
+              <TrendingUp className="w-4 h-4 text-theme-gold" />
+              <span className="text-xs font-medium text-theme-gold uppercase tracking-wide">
+                Personal Best
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              {exercise.type.includes('weight') && (
+                <Dumbbell className="w-4 h-4 text-theme-gold" />
+              )}
+              {(exercise.type.includes('reps') || exercise.type === 'reps_only') && (
+                <Repeat className="w-4 h-4 text-theme-gold" />
+              )}
+              {exercise.type === 'timed' && (
+                <Clock className="w-4 h-4 text-theme-gold" />
+              )}
+              <span className="text-theme-gold text-sm font-medium">
+                {formatPerformance(personalBest, exercise.type)}
+              </span>
+            </div>
+            {personalBest && personalBest !== lastPerformance && (
+              <div className="text-xs text-theme-gold-dark mt-1">
+                {personalBest.date}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Muscle Groups */}
+        {exercise.primaryMuscle && (
+          <div className="pt-2 border-t border-theme-gold/10">
+            <div className="text-xs text-theme-gold-dark">
+              <span className="font-medium">Primary:</span> {exercise.primaryMuscle}
+              {exercise.secondaryMuscle && exercise.secondaryMuscle.length > 0 && (
+                <>
+                  <span className="mx-2">•</span>
+                  <span className="font-medium">Secondary:</span> {exercise.secondaryMuscle.join(', ')}
+                </>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/PlanSelection.tsx
+++ b/src/components/PlanSelection.tsx
@@ -240,28 +240,22 @@ function PlanSelection({ onSelectPlan, onCreatePlan, workoutHistory }: PlanSelec
             {Object.values(WORKOUT_PLANS).map((plan) => {
               const isActivePlan = profile?.current_plan_id === plan.id && !hasGeneratedPlan;
               
+              // Skip displaying active plan here since it's shown above
+              if (isActivePlan) return null;
+              
               return (
                 <Card 
                   key={plan.id}
-                  className={`bg-theme-black-lighter border transition-all duration-300 hover:scale-[1.02] ${
-                    isActivePlan 
-                      ? 'border-theme-gold bg-theme-gold/5' 
-                      : 'border-theme-gold/20 hover:border-theme-gold/40'
-                  }`}
+                  className="bg-theme-black-lighter border transition-all duration-300 hover:scale-[1.02] border-theme-gold/20 hover:border-theme-gold/40"
                 >
                   <div className="flex flex-col md:flex-row gap-6">
                     <div className="md:w-1/3 flex flex-col items-center justify-center bg-theme-black rounded-nested-container p-4">
                       <div className="w-16 h-16 flex items-center justify-center mb-2">
                         <Dumbbell className="w-8 h-8 text-theme-gold" />
                       </div>
-                      {isActivePlan && (
-                        <div className="bg-theme-gold text-theme-black px-2 py-1 rounded-2x-nested-container text-xs font-bold mb-2">
-                          ACTIVE
-                        </div>
-                      )}
                       <div className="text-center">
                         <div className="text-theme-gold font-semibold text-sm">
-                          {isActivePlan ? `Level ${(profile?.current_level_index || 0) + 1}` : 'Pre-Made Plan'}
+                          Pre-Made Plan
                         </div>
                       </div>
                     </div>
@@ -270,14 +264,6 @@ function PlanSelection({ onSelectPlan, onCreatePlan, workoutHistory }: PlanSelec
                         <h3 className="text-2xl font-bold text-theme-gold">
                           {plan.name}
                         </h3>
-                        {isActivePlan && workoutsRemaining !== null && (
-                          <div className="flex items-center gap-2 text-theme-gold-light">
-                            <Clock className="w-4 h-4" />
-                            <span className="text-sm font-medium">
-                              {workoutsRemaining > 0 ? `${workoutsRemaining} workouts left` : 'Block Complete!'}
-                            </span>
-                          </div>
-                        )}
                       </div>
                       
                       <p className="text-theme-gold-dark">{plan.description}</p>
@@ -296,34 +282,21 @@ function PlanSelection({ onSelectPlan, onCreatePlan, workoutHistory }: PlanSelec
                       </div>
 
                       <div className="flex flex-wrap gap-3 pt-2">
-                        {!isActivePlan && (
-                          <>
-                            <PrimaryButton
-                              onClick={() => handleStartPlan(plan.id)}
-                              ariaLabel={hasActivePlan ? "Switch to This Plan" : "Start This Plan"}
-                            >
-                              <Play size={16} className="mr-1" />
-                              {hasActivePlan ? "Switch to This Plan" : "Start This Plan"}
-                            </PrimaryButton>
-                            <IconButton
-                              onClick={() => handleTryPlan(plan.id)}
-                              ariaLabel="Try Plan"
-                              className="text-theme-gold-dark hover:text-theme-gold"
-                            >
-                              <Eye size={16} className="mr-1" />
-                              Try Plan
-                            </IconButton>
-                          </>
-                        )}
-                        {isActivePlan && (
-                          <PrimaryButton
-                            onClick={() => onSelectPlan(plan.id)}
-                            ariaLabel="Continue Plan"
-                          >
-                            <Play size={16} className="mr-1" />
-                            Continue Plan
-                          </PrimaryButton>
-                        )}
+                        <PrimaryButton
+                          onClick={() => handleStartPlan(plan.id)}
+                          ariaLabel={hasActivePlan ? "Switch to This Plan" : "Start This Plan"}
+                        >
+                          <Play size={16} className="mr-1" />
+                          {hasActivePlan ? "Switch to This Plan" : "Start This Plan"}
+                        </PrimaryButton>
+                        <IconButton
+                          onClick={() => handleTryPlan(plan.id)}
+                          ariaLabel="Try Plan"
+                          className="text-theme-gold-dark hover:text-theme-gold"
+                        >
+                          <Eye size={16} className="mr-1" />
+                          Try Plan
+                        </IconButton>
                       </div>
                     </div>
                   </div>
@@ -334,6 +307,67 @@ function PlanSelection({ onSelectPlan, onCreatePlan, workoutHistory }: PlanSelec
           </div>
         )}
       </Card>
+
+      {/* Current Active Pre-Made Plan - Display above Other Plans */}
+      {hasActivePlan && !hasGeneratedPlan && (
+        <Card className="bg-gradient-to-br from-theme-gold/10 to-theme-gold/5 border-theme-gold/40 hover:border-theme-gold/60 transition-all duration-300 hover:scale-[1.02]">
+          <div className="flex flex-col md:flex-row gap-6">
+            <div className="md:w-1/3 flex flex-col items-center justify-center bg-theme-black-lighter rounded-nested-container relative p-4">
+              <div className="w-16 h-16 flex items-center justify-center">
+                <Dumbbell className="w-8 h-8 text-theme-gold" />
+              </div>
+              <div className="bg-theme-gold text-theme-black px-2 py-1 rounded-2x-nested-container text-xs font-bold mb-2">
+                ACTIVE
+              </div>
+              <div className="text-center">
+                <div className="text-theme-gold font-semibold text-sm">
+                  Level {(profile?.current_level_index || 0) + 1}
+                </div>
+              </div>
+            </div>
+            <div className="md:w-2/3 space-y-4">
+              <div className="flex justify-between items-start">
+                <h3 className="text-2xl font-bold text-theme-gold">
+                  {WORKOUT_PLANS[profile?.current_plan_id || '']?.name}
+                </h3>
+                {workoutsRemaining !== null && (
+                  <div className="flex items-center gap-2 text-theme-gold-light">
+                    <Clock className="w-4 h-4" />
+                    <span className="text-sm font-medium">
+                      {workoutsRemaining > 0 ? `${workoutsRemaining} workouts left` : 'Block Complete!'}
+                    </span>
+                  </div>
+                )}
+              </div>
+              
+              <p className="text-theme-gold-dark">{WORKOUT_PLANS[profile?.current_plan_id || '']?.description}</p>
+              
+              <div className="flex items-center gap-2 text-theme-gold-dark">
+                <Calendar className="w-5 h-5" />
+                <span>{Object.keys(WORKOUT_PLANS[profile?.current_plan_id || '']?.levels[0].workouts || {}).length} workouts per week</span>
+              </div>
+              
+              <div className="flex flex-wrap gap-2">
+                {Object.entries(WORKOUT_PLANS[profile?.current_plan_id || '']?.levels[0].workouts || {}).map(([day, workout]) => (
+                  <span key={day} className="px-3 py-1 bg-theme-black-lighter rounded-2x-nested-container text-sm text-theme-gold-dark">
+                    {day}
+                  </span>
+                ))}
+              </div>
+
+              <div className="flex flex-wrap gap-3 pt-2">
+                <PrimaryButton
+                  onClick={() => onSelectPlan(profile?.current_plan_id || '')}
+                  ariaLabel="Continue Plan"
+                >
+                  <Play size={16} className="mr-1" />
+                  Continue Plan
+                </PrimaryButton>
+              </div>
+            </div>
+          </div>
+        </Card>
+      )}
 
       {/* Workout History Section */}
       <Card className="bg-theme-black-light border border-theme-gold/20">

--- a/src/components/PlanSelection.tsx
+++ b/src/components/PlanSelection.tsx
@@ -369,6 +369,37 @@ function PlanSelection({ onSelectPlan, onCreatePlan, workoutHistory }: PlanSelec
         )}
       </Card>
 
+      {/* Workout History Section */}
+      <Card className="bg-theme-black-light border border-theme-gold/20">
+        <button 
+          onClick={() => setShowHistory(!showHistory)}
+          className="w-full flex justify-between items-center text-left text-xl font-semibold text-theme-gold hover:text-theme-gold-light transition-colors py-2"
+        >
+          Workout History
+          {showHistory ? <MinusCircle size={24} /> : <PlusCircle size={24} />}
+        </button>
+        {showHistory && (
+          <div className="mt-4 space-y-4 max-h-96 overflow-y-auto pr-2">
+            {Object.keys(workoutHistory).length > 0 ? (
+              Object.entries(workoutHistory).map(([date, logs]) => (
+                <div key={date} className="p-3 bg-theme-black-lighter rounded-nested-container border border-theme-gold/10">
+                  <h3 className="text-md font-semibold text-theme-gold-light mb-2">{date}</h3>
+                  <ul className="space-y-1 text-sm">
+                    {logs.map((log, index) => (
+                      <li key={index} className="text-theme-gold-dark">
+                        {log.exercise_name} - Set {log.set_number}: {log.weight ? `${log.weight} lbs/kg, ` : ''}{log.reps_logged} reps {log.duration_seconds ? `(${log.duration_seconds}s)` : ''}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))
+            ) : (
+              <p className="text-theme-gold-dark">No workout history yet. Complete a workout to see your logs!</p>
+            )}
+          </div>
+        )}
+      </Card>
+
       {/* Switch Plan Confirmation Modal */}
       <Modal 
         isOpen={showSwitchModal} 

--- a/src/components/PlanSelection.tsx
+++ b/src/components/PlanSelection.tsx
@@ -369,40 +369,6 @@ function PlanSelection({ onSelectPlan, onCreatePlan, workoutHistory }: PlanSelec
         )}
       </Card>
 
-      {/* Current Active Pre-Made Plan - Display above Other Plans */}
-      {hasActivePlan && !hasGeneratedPlan && (
-        <Card className="bg-gradient-to-br from-theme-gold/10 to-theme-gold/5 border-theme-gold/40 hover:border-theme-gold/60 transition-all duration-300 hover:scale-[1.02]">
-          <div className="flex flex-col md:flex-row gap-6">
-            <div className="md:w-1/3 flex flex-col items-center justify-center bg-theme-black-lighter rounded-nested-container relative p-4">
-              <div className="w-16 h-16 flex items-center justify-center">
-                <Dumbbell className="w-8 h-8 text-theme-gold" />
-              </div>
-              <div className="bg-theme-gold text-theme-black px-2 py-1 rounded-2x-nested-container text-xs font-bold mb-2">
-                ACTIVE
-              </div>
-              <div className="text-center">
-                <div className="text-theme-gold font-semibold text-sm">
-                  Level {(profile?.current_level_index || 0) + 1}
-                </div>
-              </div>
-            </div>
-            <div className="md:w-2/3 space-y-4">
-              <div className="flex justify-between items-start">
-                <h3 className="text-2xl font-bold text-theme-gold">
-                  {WORKOUT_PLANS[profile?.current_plan_id || '']?.name}
-                </h3>
-                {workoutsRemaining !== null && (
-                  <div className="flex items-center gap-2 text-theme-gold-light">
-                    <Clock className="w-4 h-4" />
-                    <span className="text-sm font-medium">
-                      {workoutsRemaining > 0 ? `${workoutsRemaining} workouts left` : 'Block Complete!'}
-                    </span>
-                  </div>
-                )}
-              </div>
-              
-              <p className="text-theme-gold-dark">{WORKOUT_PLANS[profile?.current_plan_id || '']?.description}</p>
-
       {/* Switch Plan Confirmation Modal */}
       <Modal 
         isOpen={showSwitchModal} 

--- a/src/components/PlanSelection.tsx
+++ b/src/components/PlanSelection.tsx
@@ -176,6 +176,67 @@ function PlanSelection({ onSelectPlan, onCreatePlan, workoutHistory }: PlanSelec
         </Card>
       )}
 
+      {/* Current Active Pre-Made Plan - Display above Other Plans */}
+      {hasActivePlan && !hasGeneratedPlan && (
+        <Card className="bg-gradient-to-br from-theme-gold/10 to-theme-gold/5 border-theme-gold/40 hover:border-theme-gold/60 transition-all duration-300 hover:scale-[1.02]">
+          <div className="flex flex-col md:flex-row gap-6">
+            <div className="md:w-1/3 flex flex-col items-center justify-center bg-theme-black-lighter rounded-nested-container relative p-4">
+              <div className="w-16 h-16 flex items-center justify-center">
+                <Dumbbell className="w-8 h-8 text-theme-gold" />
+              </div>
+              <div className="bg-theme-gold text-theme-black px-2 py-1 rounded-2x-nested-container text-xs font-bold mb-2">
+                ACTIVE
+              </div>
+              <div className="text-center">
+                <div className="text-theme-gold font-semibold text-sm">
+                  Level {(profile?.current_level_index || 0) + 1}
+                </div>
+              </div>
+            </div>
+            <div className="md:w-2/3 space-y-4">
+              <div className="flex justify-between items-start">
+                <h3 className="text-2xl font-bold text-theme-gold">
+                  {WORKOUT_PLANS[profile?.current_plan_id || '']?.name}
+                </h3>
+                {workoutsRemaining !== null && (
+                  <div className="flex items-center gap-2 text-theme-gold-light">
+                    <Clock className="w-4 h-4" />
+                    <span className="text-sm font-medium">
+                      {workoutsRemaining > 0 ? `${workoutsRemaining} workouts left` : 'Block Complete!'}
+                    </span>
+                  </div>
+                )}
+              </div>
+              
+              <p className="text-theme-gold-dark">{WORKOUT_PLANS[profile?.current_plan_id || '']?.description}</p>
+              
+              <div className="flex items-center gap-2 text-theme-gold-dark">
+                <Calendar className="w-5 h-5" />
+                <span>{Object.keys(WORKOUT_PLANS[profile?.current_plan_id || '']?.levels[0].workouts || {}).length} workouts per week</span>
+              </div>
+              
+              <div className="flex flex-wrap gap-2">
+                {Object.entries(WORKOUT_PLANS[profile?.current_plan_id || '']?.levels[0].workouts || {}).map(([day, workout]) => (
+                  <span key={day} className="px-3 py-1 bg-theme-black-lighter rounded-2x-nested-container text-sm text-theme-gold-dark">
+                    {day}
+                  </span>
+                ))}
+              </div>
+
+              <div className="flex flex-wrap gap-3 pt-2">
+                <PrimaryButton
+                  onClick={() => onSelectPlan(profile?.current_plan_id || '')}
+                  ariaLabel="Continue Plan"
+                >
+                  <Play size={16} className="mr-1" />
+                  Continue Plan
+                </PrimaryButton>
+              </div>
+            </div>
+          </div>
+        </Card>
+      )}
+
       {/* Pre-Made Plans / Other Plans Section */}
       <Card className="bg-theme-black-light border border-theme-gold/20">
         <button 
@@ -341,66 +402,6 @@ function PlanSelection({ onSelectPlan, onCreatePlan, workoutHistory }: PlanSelec
               </div>
               
               <p className="text-theme-gold-dark">{WORKOUT_PLANS[profile?.current_plan_id || '']?.description}</p>
-              
-              <div className="flex items-center gap-2 text-theme-gold-dark">
-                <Calendar className="w-5 h-5" />
-                <span>{Object.keys(WORKOUT_PLANS[profile?.current_plan_id || '']?.levels[0].workouts || {}).length} workouts per week</span>
-              </div>
-              
-              <div className="flex flex-wrap gap-2">
-                {Object.entries(WORKOUT_PLANS[profile?.current_plan_id || '']?.levels[0].workouts || {}).map(([day, workout]) => (
-                  <span key={day} className="px-3 py-1 bg-theme-black-lighter rounded-2x-nested-container text-sm text-theme-gold-dark">
-                    {day}
-                  </span>
-                ))}
-              </div>
-
-              <div className="flex flex-wrap gap-3 pt-2">
-                <PrimaryButton
-                  onClick={() => onSelectPlan(profile?.current_plan_id || '')}
-                  ariaLabel="Continue Plan"
-                >
-                  <Play size={16} className="mr-1" />
-                  Continue Plan
-                </PrimaryButton>
-              </div>
-            </div>
-          </div>
-        </Card>
-      )}
-
-      {/* Workout History Section */}
-      <Card className="bg-theme-black-light border border-theme-gold/20">
-        <button 
-          onClick={() => setShowHistory(!showHistory)}
-          className="w-full flex justify-between items-center text-left text-xl font-semibold text-theme-gold hover:text-theme-gold-light transition-colors py-2"
-        >
-          Workout History
-          {showHistory ? <ChevronUp size={24} /> : <ChevronDown size={24} />}
-        </button>
-        {showHistory && (
-          <div className="mt-4 space-y-4 max-h-96 overflow-y-auto pr-2">
-            {Object.keys(workoutHistory).length > 0 ? (
-              Object.entries(workoutHistory)
-                .sort((a, b) => new Date(b[0]).getTime() - new Date(a[0]).getTime())
-                .map(([date, logs]) => (
-                <div key={date} className="p-3 bg-theme-black-lighter rounded-nested-container border border-theme-gold/10">
-                  <h3 className="text-md font-semibold text-theme-gold-light mb-2">{date}</h3>
-                  <ul className="space-y-1 text-sm">
-                    {logs.map((log, index) => (
-                      <li key={index} className="text-theme-gold-dark">
-                        {log.workout_day} - {log.exercise_name} - Set {log.set_number}: {log.weight ? `${log.weight} lbs/kg, ` : ''}{log.reps_logged} reps {log.duration_seconds ? `(${log.duration_seconds}s)` : ''}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))
-            ) : (
-              <p className="text-theme-gold-dark">No workout history yet. Complete a workout to see your logs!</p>
-            )}
-          </div>
-        )}
-      </Card>
 
       {/* Switch Plan Confirmation Modal */}
       <Modal 

--- a/src/components/WorkoutSession.tsx
+++ b/src/components/WorkoutSession.tsx
@@ -717,8 +717,8 @@ function WorkoutSession({ day, plan, onGoHome, onLogWorkout }: WorkoutSessionPro
               onSkip={skipRest}
             />
             
-            {/* Next Exercise Preview */}
-            {enhancedNextExercise && (
+            {/* Next Exercise Preview - Only show after final set of current exercise */}
+            {enhancedNextExercise && justCompletedFinalSet && (
               <div className="mt-4">
                 <NextExercisePreview
                   exercise={enhancedNextExercise}

--- a/src/components/WorkoutSession.tsx
+++ b/src/components/WorkoutSession.tsx
@@ -8,8 +8,10 @@ import { Card } from './ui/Card';
 import { Modal } from './ui/Modal';
 import { ExerciseHistory } from './ExerciseHistory';
 import { TrainingBlockCompleteModal } from './TrainingBlockCompleteModal';
+import { NextExercisePreview } from './NextExercisePreview';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../hooks/useAuth';
+import { useExerciseHistory } from '../hooks/useExerciseHistory';
 import { useUserProfile } from '../hooks/useUserProfile';
 import type { Exercise, WorkoutPlan } from '../data/workoutData';
 
@@ -258,6 +260,7 @@ function WorkoutSession({ day, plan, onGoHome, onLogWorkout }: WorkoutSessionPro
   const [reps, setReps] = useState('');
   const [duration, setDuration] = useState('');
   const [loggedSetsForExercise, setLoggedSetsForExercise] = useState<any[]>([]);
+  const [nextExerciseDetails, setNextExerciseDetails] = useState<any>(null);
   
   // Timer state with timestamp-based tracking
   const [timerActive, setTimerActive] = useState(false);
@@ -289,6 +292,14 @@ function WorkoutSession({ day, plan, onGoHome, onLogWorkout }: WorkoutSessionPro
   const currentExercise = currentWorkout?.exercises[currentExerciseIndex];
   const enhancedCurrentExercise = currentExercise ? getEnhancedExercise(currentExercise) : null;
 
+  // Get next exercise details and history
+  const nextExercise = currentWorkout?.exercises[currentExerciseIndex + 1];
+  const enhancedNextExercise = nextExercise ? getEnhancedExercise(nextExercise) : null;
+  const { history: nextExerciseHistory, loading: nextExerciseHistoryLoading } = useExerciseHistory(
+    enhancedNextExercise?.id || '',
+    enhancedNextExercise?.name || ''
+  );
+
   useEffect(() => {
     if (!enhancedCurrentExercise) return;
     
@@ -304,6 +315,14 @@ function WorkoutSession({ day, plan, onGoHome, onLogWorkout }: WorkoutSessionPro
     setTimedExerciseStartTime(null);
     setTimedExerciseElapsed(0);
     setJustCompletedFinalSet(false);
+    
+    // Update next exercise details
+    if (currentWorkout?.exercises[currentExerciseIndex + 1]) {
+      const nextEx = currentWorkout.exercises[currentExerciseIndex + 1];
+      setNextExerciseDetails(getEnhancedExercise(nextEx));
+    } else {
+      setNextExerciseDetails(null);
+    }
   }, [currentExerciseIndex, enhancedCurrentExercise?.type, enhancedCurrentExercise?.reps]);
 
   // Timer effect with timestamp-based calculation
@@ -697,6 +716,17 @@ function WorkoutSession({ day, plan, onGoHome, onLogWorkout }: WorkoutSessionPro
               isActive={timerActive}
               onSkip={skipRest}
             />
+            
+            {/* Next Exercise Preview */}
+            {enhancedNextExercise && (
+              <div className="mt-4">
+                <NextExercisePreview
+                  exercise={enhancedNextExercise}
+                  history={nextExerciseHistory}
+                  loading={nextExerciseHistoryLoading}
+                />
+              </div>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
Implemented a new NextExercisePreview component that displays details of the next exercise (name, sets, reps) and its historical performance (last performance, personal best) during the rest period. This preview is now only shown after the final set of an exercise, allowing users to prepare for the transition to the next distinct exercise in their workout.

**Home screen**
The active user plan (whether generated or pre-made) is now prominently displayed above the "Other Plans" expansion panel, ensuring it's immediately visible and clearly indicates the user's current program.
